### PR TITLE
Ajustes para Rails 5.1

### DIFF
--- a/app/controllers/crud_controller.rb
+++ b/app/controllers/crud_controller.rb
@@ -1,5 +1,5 @@
 class CrudController < ApplicationController
-  before_filter :setup, except: :autocomplete
+  before_action :setup, except: :autocomplete
 
   private
   def setup

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  before_filter :authenticate_usuario!, :unless => :devise_controller?
-  around_filter :set_current_usuario
-  
+  before_action :authenticate_usuario!, :unless => :devise_controller?
+  around_action :set_current_usuario
+
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
       format.html {
@@ -19,18 +19,18 @@ class ApplicationController < ActionController::Base
       }
     end
   end
-  
+
   def current_ability
     @current_ability ||= Ability.new(current_usuario)
   end
 
   def set_current_usuario
     Usuario.current = current_usuario
-    yield 
+    yield
   ensure
     Usuario.current = nil
   end
-  
+
   def query
     @resource = Module.const_get(params[:model].classify)
     @q = @resource.search(params[:q])
@@ -47,5 +47,5 @@ class ApplicationController < ActionController::Base
       render :partial => params[:partial]
     end
   end
-  
+
 end


### PR DESCRIPTION
Atualizei o Pagir para usar o rails 5.0.2, e recebi uma mensagem dizendo que os `before_filter` vão ser removidos no rails 5.1. Já troquei neste branch todos p/ `before_action`.