### PR TITLE
Checkbox on search rails5

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,18 +131,18 @@ campo_formulario :data_nascimento, input_html: {class: "i-checks"}
 Os campos checkbox podem ser campo_formulario e/ou campo_busca
 
 ```rb
-campo_formulario :competencias,
+campo_formulario :sexo,
                  label: 'simple_form.labels.perfil.perfis_perfil',
                  as: :check_boxes,
                  input_html: {class: "i-checks"},
-                 collection_if: [1, 2, 3]
+                 collection_if: Proc.new { User.sexos.map{|s| [s, s]} }
 ```
 
 ```rb
-campo_busca :competencias,
+campo_busca :sexo,
             as: :check_boxes,
             input_html: {class: "i-checks"}
-            collection: [1, 2, 3]
+            collection: Proc.new { User.sexos.map{|s| [s, s]} }
 ```
 
 ## Busca por intervalo

--- a/README.md
+++ b/README.md
@@ -131,15 +131,29 @@ campo_formulario :data_nascimento, input_html: {class: "i-checks"}
 Os campos checkbox podem ser campo_formulario e/ou campo_busca
 
 ```rb
-campo_formulario :competencias, label: "competencias", as: :check_boxes input_html: {class: "i-checks"}
+campo_formulario :competencias,
+                 label: 'simple_form.labels.perfil.perfis_perfil',
+                 as: :check_boxes,
+                 input_html: {class: "i-checks"},
+                 collection_if: [1, 2, 3]
 ```
 
 ```rb
-campo_busca :competencias, label: "competencias", as: :check_boxes input_html: {class: "i-checks"}
+campo_busca :competencias,
+            as: :check_boxes,
+            input_html: {class: "i-checks"}
+            collection: [1, 2, 3]
 ```
 
 ## Busca por intervalo
 Para buscas de valores em um intervalo
+
+```rb
+campo_busca :salario, label: "simple_form.labels.perfil.perfis_perfil", as: :range
+```
+
+## Aplicando máscara
+Para aplicar uma máscara em um campo
 
 ```rb
 campo_formulario :data_nascimento, input_html: {"data-mask" => "(99) 9999-9999"}

--- a/README.md
+++ b/README.md
@@ -127,8 +127,19 @@ Para vincular o *iCheck* no campo do tipo boolena
 campo_formulario :data_nascimento, input_html: {class: "i-checks"}
 ```
 
-## Aplicando máscara
-Para aplicar uma máscara em um campo
+## Campos do tipo check_boxes
+Os campos checkbox podem ser campo_formulario e/ou campo_busca
+
+```rb
+campo_formulario :competencias, label: "competencias", as: :check_boxes input_html: {class: "i-checks"}
+```
+
+```rb
+campo_busca :competencias, label: "competencias", as: :check_boxes input_html: {class: "i-checks"}
+```
+
+## Busca por intervalo
+Para buscas de valores em um intervalo
 
 ```rb
 campo_formulario :data_nascimento, input_html: {"data-mask" => "(99) 9999-9999"}

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -81,7 +81,7 @@ module SearchHelper
       case opts[:as]
       when :select
         if opts[:collection_if] and opts[:collection_if].class == Proc
-          opts[:collection] = ActionView::Helpers::FormBuilder.instance_eval &opts[:collection_if]
+          opts[:collection] = ActionView::Helpers::FormBuilder.instance_eval(&opts[:collection_if])
         end
         raro_select(name,opts,opts[:collection])
       when :hidden
@@ -92,6 +92,13 @@ module SearchHelper
         raro_range(name)
       when :monthyear
         raro_monthyear(name, opts)
+      when :check_boxes
+        if opts.key?(:collection)
+          collection = opts[:collection]
+        else
+          collection = opts[:collection_if].call
+        end
+        return raro_check_boxes(name, opts, collection)
       end
     end
 
@@ -103,6 +110,23 @@ module SearchHelper
         collection.push([e.id,val])
       end
       return raro_select("q[#{model_name}_id_eq]",opts,collection)
+    end
+
+    def raro_check_boxes(name, opts, collection)
+      unless opts[:model]
+        name = "q[#{name}_eq]"
+      end
+      buf = "<div class='col-sm-12'>"
+      input_class = opts[:input_html].try(:[], :class)
+      collection.each do |e|
+        buf << "<span class='checkbox' style='display: inline;'>"
+        buf << "<label for='vaga_filtro_vaga_attributes_perfil_executor' class='control-label'>"
+        buf << "<input class='form-control check_boxes optional #{input_class}' type='checkbox' value='#{e[0]}' name='#{name}' style=''> #{e[1]}"
+        buf << '</label>'
+        buf << '</span>'
+      end
+      buf << '</div>'
+      return buf
     end
 
     def raro_select(name,opts,collection)

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -78,11 +78,11 @@ module SearchHelper
     end
 
     def raro_input_as(name,type,opts)
+      if opts[:collection_if] and opts[:collection_if].class == Proc
+        opts[:collection] = ActionView::Helpers::FormBuilder.instance_eval(&opts[:collection_if])
+      end
       case opts[:as]
       when :select
-        if opts[:collection_if] and opts[:collection_if].class == Proc
-          opts[:collection] = ActionView::Helpers::FormBuilder.instance_eval(&opts[:collection_if])
-        end
         raro_select(name,opts,opts[:collection])
       when :hidden
         return raro_hidden_field(name,opts[:value],opts)
@@ -93,12 +93,7 @@ module SearchHelper
       when :monthyear
         raro_monthyear(name, opts)
       when :check_boxes
-        if opts.key?(:collection)
-          collection = opts[:collection]
-        else
-          collection = opts[:collection_if].call
-        end
-        return raro_check_boxes(name, opts, collection)
+        raro_check_boxes(name, opts, opts[:collection])
       end
     end
 


### PR DESCRIPTION
# Contexto

Inclusão de campo_busca do tipo check_box

exemple de inserção:

```ruby
campo_busca :perfil,
              label: 'Busca Checkbox',
              model: 'Perfil',
              full_name: 'q[by_profile]',
              dont_assoc: false,
              as: :check_boxes,
              input_html: {
                class: 'i-checks'
              },
              collection_if: { value_do_campo: "nome do campo }
```